### PR TITLE
Update CI workflow to match package with working TagBot

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -23,15 +23,18 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1'
+          - '1.11'
         os:
           - ubuntu-latest
-          - macOS-latest
           - windows-latest
         arch:
           - x64
+        include:
+          - os: macOS-latest
+            arch: aarch64
+            version: 1
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
@@ -42,9 +45,7 @@ jobs:
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v5
         with:
-          files: lcov.info
           token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: false
   docs:
     name: Documentation
     runs-on: ubuntu-latest
@@ -73,6 +74,6 @@ jobs:
         shell: julia --project=docs --color=yes {0}
         run: |
           using Documenter: DocMeta, doctest
-          using CellMetabolism
-          DocMeta.setdocmeta!(CellMetabolism, :DocTestSetup, :(using CellMetabolism); recursive=true)
-          doctest(CellMetabolism)
+          using CellMetabolismBase
+          DocMeta.setdocmeta!(CellMetabolismBase, :DocTestSetup, :(using CellMetabolismBase); recursive=true)
+          doctest(CellMetabolismBase)


### PR DESCRIPTION
Updated CI workflow to use Julia version 1.11 and changed checkout action version to v5. Added macOS aarch64 configuration and modified doctest setup.