### PR TITLE
Bump to OrdinaryDiffEq 7 / CellMetabolismBase 0.4

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -32,8 +32,3 @@ BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 
 [targets]
 test = ["Aqua", "JET", "Test", "TestItemRunner", "BenchmarkTools", "OrdinaryDiffEq"]
-
-# TEMPORARY: bridges the mutual CellMetabolism <-> CellMetabolismBase bump while
-# CellMetabolismBase 0.4 is unregistered. Remove this section before registering.
-[sources]
-CellMetabolismBase = {url = "https://github.com/DenisTitovLab/CellMetabolismBase.jl", rev = "bump-ordinarydiffeq-v7"}

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CellMetabolism"
 uuid = "d7c5e2dd-9163-4219-82bc-37cddd708ca9"
 authors = ["Denis Titov <titov@berkeley.edu>  and contributors"]
-version = "0.2.2"
+version = "0.3.0"
 
 [deps]
 CellMetabolismBase = "29f58b35-15e1-4d3c-99d7-eccaac145095"
@@ -10,17 +10,17 @@ Measurements = "eff96d63-e80a-5855-80a2-b1b0885c5ab7"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 
 [compat]
-CellMetabolismBase = "0.3.1"
+CellMetabolismBase = "0.4"
 LabelledArrays = "1.16.0"
 Measurements = "2.12.0"
 Aqua = "0.8.11"
 BenchmarkTools = "1.6"
 Distributions = "0.25.117"
 JET = "0.10, 0.11"
-OrdinaryDiffEq = "6.91"
+OrdinaryDiffEq = "7"
 Test = "1.10"
 TestItemRunner = "1.1.0"
-julia = "1.10, 1.11, 1.12"
+julia = "1.10"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
@@ -32,3 +32,8 @@ BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 
 [targets]
 test = ["Aqua", "JET", "Test", "TestItemRunner", "BenchmarkTools", "OrdinaryDiffEq"]
+
+# TEMPORARY: bridges the mutual CellMetabolism <-> CellMetabolismBase bump while
+# CellMetabolismBase 0.4 is unregistered. Remove this section before registering.
+[sources]
+CellMetabolismBase = {url = "https://github.com/DenisTitovLab/CellMetabolismBase.jl", rev = "bump-ordinarydiffeq-v7"}


### PR DESCRIPTION
## Why

Companion to [CellMetabolismBase#36](https://github.com/DenisTitovLab/CellMetabolismBase.jl/pull/36). `OrdinaryDiffEq` v7 (the v7 / DifferentialEquations v8 generation) couples `SciMLBase 3` and `RecursiveArrayTools 4`, the same set CellMetabolismBase is moving to — so the two packages must bump together.

## Changes

**Compat** (`Project.toml`)
- `OrdinaryDiffEq = "7"`, `CellMetabolismBase = "0.4"`
- `julia = "1.10"` (LTS floor)
- version → **0.3.0** (requiring CellMetabolismBase 0.4 is a breaking floor change)

**Code** — none. CellMetabolism is pure pathway/enzyme definitions plus a `CellMetabolismBase.validate` call; it never solves ODEs (the `OrdinaryDiffEq` test import isn't even exercised). The test suite passes unchanged on OrdinaryDiffEq 7.1 / SciMLBase 3.21 / RecursiveArrayTools 4.3.

## Rollout note

The temporary `[sources]` entry points `CellMetabolismBase` at its unregistered [#36](https://github.com/DenisTitovLab/CellMetabolismBase.jl/pull/36) branch so CI can resolve. **Remove `[sources]` before registering.** Register CellMetabolismBase 0.4.0 first, then this 0.3.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)