### PR TITLE
Fix rate-function unit labels: M/s → M/min (#27)

### DIFF
--- a/examples/2026_F26BP_Figures/Fig1BC_effect_of_F26BP_on_glyc_resp_w_wo_resp.jl
+++ b/examples/2026_F26BP_Figures/Fig1BC_effect_of_F26BP_on_glyc_resp_w_wo_resp.jl
@@ -211,7 +211,7 @@ for cond in conditions
     ax = Axis(
         fig[1, cond.col],
         xlabel = "[F26BP], M",
-        ylabel = "Rate of ATP cons. or prod., M/s",
+        ylabel = "Rate of ATP cons. or prod., M/min",
         title = cond.title,
         xscale = log10,
         xticklabelsize = 10,

--- a/examples/2026_F26BP_Figures/SupplFig_effect_of_F26BP_on_rates_varying_resp_glyc_ratio.jl
+++ b/examples/2026_F26BP_Figures/SupplFig_effect_of_F26BP_on_rates_varying_resp_glyc_ratio.jl
@@ -235,7 +235,7 @@ for cond in conditions
     ax = Axis(
         fig[1, cond.col],
         xlabel = "[F26BP], M",
-        ylabel = "Rate of ATP cons. or prod., M/s",
+        ylabel = "Rate of ATP cons. or prod., M/min",
         title = cond.title,
         xscale = log10,
         xticklabelsize = 10,

--- a/src/enzyme_rates_and_parameters.jl
+++ b/src/enzyme_rates_and_parameters.jl
@@ -193,14 +193,14 @@ glycolysis_params = Measurements.value.(glycolysis_params_w_uncertainty)
 
 #=
     This file contains functions that take M concentrations of glycolytic metabolites as input and
-    and generate rates of glycolytic reactions in M/s
+    and generate rates of glycolytic reactions in M/min
 =#
 
 
 """
     rate(::Enzyme{:GLUT1}, metabs, params)
 
-Calculate rate (M/s units) of GLUT transporter from concentrations (M units) of `Glucose_media` and `Glucose` according to the following equation:
+Calculate rate (M/min units) of GLUT transporter from concentrations (M units) of `Glucose_media` and `Glucose` according to the following equation:
 
 ```math
 Rate = \\frac{{V_{max} \\cdot Conc}}{{K_{M}^{Glucose}}} \\cdot \\frac{{Glucose_{media} - \\frac{1}{K_{eq}} \\cdot Glucose}}{1 + \\frac{Glucose_{media}}{K_{M}^{Glucose}} + \\frac{Glucose}{K_{M}^{Glucose}}}


### PR DESCRIPTION
## Summary

Enzyme rate functions return rates in **M/min**, not **M/s**. This corrects the unit labels in two docstring locations and two figure y-axis labels. The computation itself is already correct and internally consistent in M/min — this is a documentation/label-only fix (off by 60× when read literally).

### Why M/min is correct
- **Vmax units:** `Vmax` values are specific activities in `U/mg = µmol/min/mg`. Dimensionally, `Vmax · Conc = µmol/min/mg × mg/µL = (mol/L)/min = M/min`.
- **No time rescaling:** neither the rate laws nor `CellMetabolismBase.make_ODEProblem`'s `du ± rate·stoich` assembly contains any `÷60`, so the ODE's native time unit is minutes.
- **Turnover numbers:** computing `kcat = Vmax · MW` for the glycolytic enzymes gives literature-consistent values only under the M/min reading; the M/s reading is 60× too fast for every enzyme.
- The `Fig2_general_model_behavior_and_validation.jl` validation figure already plots model `sol.t` directly against experimental data in `time (min)` with no rescaling, confirming minutes is the native unit.

## Changes
- `src/enzyme_rates_and_parameters.jl` — file-header comment + GLUT1 `rate` docstring
- `examples/2026_F26BP_Figures/Fig1BC_effect_of_F26BP_on_glyc_resp_w_wo_resp.jl` — y-axis label
- `examples/2026_F26BP_Figures/SupplFig_effect_of_F26BP_on_rates_varying_resp_glyc_ratio.jl` — y-axis label

No computation changed.

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)